### PR TITLE
Rubocop version bump to match Codacy

### DIFF
--- a/lib/reach_linters/version.rb
+++ b/lib/reach_linters/version.rb
@@ -1,3 +1,3 @@
 module ReachLinters
-  VERSION = '2018.10.16.rev0'.freeze
+  VERSION = '2018.11.15.rev0'.freeze
 end

--- a/reach_linters.gemspec
+++ b/reach_linters.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "guard-brakeman"
   s.add_dependency "guard-bundler-audit"
-  s.add_dependency "rubocop", "~> 0.56.0"
+  s.add_dependency "rubocop", "~> 0.60.0"
 end


### PR DESCRIPTION
Codacy has their Rubocop set to version 0.60.0; so we need ours to match.