### PR TITLE
Change some ESLint errors to warnings

### DIFF
--- a/configs/.eslintrc.json
+++ b/configs/.eslintrc.json
@@ -21,441 +21,171 @@
   },
   "extends": "eslint:recommended",
   "rules": {
-    "indent": [
-      "error",
-      2
-    ],
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
-    "semi": [
-      "error",
-      "always"
-    ],
-    "array-bracket-spacing": [
-      "error",
-      "never"
-    ],
-    "object-curly-spacing": [
-      "error",
-      "never"
-    ],
-    "multiline-ternary": [
-      "error",
-      "never"
-    ],
-    "comma-dangle": [
-      "error",
-      "never"
-    ],
-    "no-confusing-arrow": [
-      "error",
-      {
-        "allowParens": false
-      }
-    ],
-    "no-duplicate-imports": [
-      "error"
-    ],
-    "no-empty-function": [
-      "error"
-    ],
-    "no-extra-label": [
-      "error"
-    ],
-    "no-implicit-globals": [
-      "error"
-    ],
-    "no-mixed-operators": [
-      "error"
-    ],
-    "quote-props": [
-      "error",
-      "as-needed"
-    ],
-    "semi-spacing": [
-      "error"
-    ],
-    "no-tabs": [
-      "error"
-    ],
-    "no-unmodified-loop-condition": [
-      "error"
-    ],
-    "no-useless-computed-key": [
-      "error"
-    ],
-    "no-useless-constructor": [
-      "error"
-    ],
-    "no-useless-rename": [
-      "error"
-    ],
-    "no-whitespace-before-property": [
-      "error"
-    ],
-    "no-extra-parens": [
-      "error",
-      "all",
-      {
-        "nestedBinaryExpressions": false
-      }
-    ],
-    "object-curly-newline": [
-      "error"
-    ],
-    "object-property-newline": [
-      "error"
-    ],
-    "one-var-declaration-per-line": [
-      "error"
-    ],
-    "space-before-function-paren": [
-      "error",
-      "never"
-    ],
-    "keyword-spacing": [
-      "error"
-    ],
-    "space-unary-ops": [
-      "error",
-      {
-        "words": true,
-        "nonwords": false
-      }
-    ],
-    "spaced-comment": [
-      "error"
-    ],
-    "no-var": [
-      "off"
-    ],
-    "prefer-const": [
-      "off"
-    ],
-    "eqeqeq": [
-      "off"
-    ],
-    "operator-assignment": [
-      "error"
-    ],
-    "brace-style": [
-      "error",
-      "1tbs",
-      {
-        "allowSingleLine": true
-      }
-    ],
-    "handle-callback-err": [
-      "error"
-    ],
-    "consistent-return": [
-      "off"
-    ],
-    "curly": [
-      "error",
-      "all"
-    ],
-    "func-style": [
-      "off"
-    ],
-    "guard-for-in": [
-      "off"
-    ],
-    "valid-jsdoc": [
-      "off"
-    ],
-    "jsx-quotes": [
-      "off"
-    ],
-    "object-shorthand": [
-      "off" // es6
-    ],
-    "computed-property-spacing": [
-      "error"
-    ],
-    "callback-return": [
-      "error"
-    ],
-    "prefer-arrow-callback": [
-      "off"
-    ],
-    "camelcase": [
-      "error"
-    ],
-    "dot-location": [
-      "error",
-      "property"
-    ],
-    "default-case": [
-      "error"
-    ],
-    "lines-around-comment": [
-      "off"
-    ],
-    "accessor-pairs": [
-      "off"
-    ],
-    "id-length": [
-      "error",
-      {
-        "min": 1,
-        "max": 25
-      }
-    ],
-    "use-isnan": [
-      "error"
-    ],
-    "padded-blocks": [
-      "error",
-      "never"
-    ],
-    "space-infix-ops": [
-      "off"
-    ],
-    "comma-style": [
-      "error",
-      "last"
-    ],
-    "comma-spacing": [
-      "error"
-    ],
-    "no-with": [
-      "error"
-    ],
-    "operator-linebreak": [
-      "error",
-      "after"
-    ],
-    "no-useless-call": [
-      "error"
-    ],
-    "no-array-constructor": [
-      "error"
-    ],
-    "no-return-assign": [
-      "error",
-      "always"
-    ],
-    "no-sequences": [
-      "error"
-    ],
-    "no-underscore-dangle": [
-      "off"
-    ],
-    "no-extend-native": [
-      "error"
-    ],
-    "no-floating-decimal": [
-      "error"
-    ],
-    "no-param-reassign": [
-      "error"
-    ],
-    "no-new-func": [
-      "error"
-    ],
-    "no-loop-func": [
-      "error"
-    ],
-    "no-implied-eval": [
-      "error"
-    ],
-    "no-undef-init": [
-      "error"
-    ],
-    "no-iterator": [
-      "error"
-    ],
-    "no-label-var": [
-      "error"
-    ],
-    "no-mixed-requires": [
-      "error"
-    ],
-    "no-multi-str": [
-      "error"
-    ],
-    "no-nested-ternary": [
-      "error"
-    ],
-    "no-eq-null": [
-      "error"
-    ],
-    "no-new-object": [
-      "error"
-    ],
-    "no-octal-escape": [
-      "error"
-    ],
-    "no-new-wrappers": [
-      "error"
-    ],
-    "no-div-regex": [
-      "error"
-    ],
-    "no-script-url": [
-      "error"
-    ],
-    "no-self-compare": [
-      "error"
-    ],
-    "no-shadow": [
-      "error"
-    ],
-    "no-catch-shadow": [
-      "error"
-    ],
-    "no-shadow-restricted-names": [
-      "error"
-    ],
-    "func-call-spacing": [
-      "error"
-    ],
-    "no-sync": [
-      "error"
-    ],
-    "no-ternary": [
-      "off"
-    ],
-    "no-unused-expressions": [
-      "error"
-    ],
-    "no-unused-vars": [
-      "error",
-      {"argsIgnorePattern": "^_"}
-    ],
-    "no-warning-comments": [
-      "error"
-    ],
-    "no-caller": [
-      "error"
-    ],
-    "no-path-concat": [
-      "error"
-    ],
-    "no-continue": [
-      "error"
-    ],
-    "no-eval": [
-      "error"
-    ],
-    "no-inline-comments": [
-      "off"
-    ],
-    "no-lonely-if": [
-      "error"
-    ],
-    "no-multiple-empty-lines": [
-      "error",
-      {
-        "max": 1,
-        "maxEOF": 1,
-        "maxBOF": 0
-      }
-    ],
-    "no-multi-spaces": [
-      "error"
-    ],
-    "no-negated-condition": [
-      "error"
-    ],
-    "no-new": [
-      "error"
-    ],
-    "no-new-require": [
-      "error"
-    ],
-    "no-process-env": [
-      "error"
-    ],
-    "no-process-exit": [
-      "error"
-    ],
-    "no-else-return": [
-      "error"
-    ],
-    "dot-notation": [
-      "error"
-    ],
-    "no-use-before-define": [
-      "error"
-    ],
-    "no-trailing-spaces": [
-      "error"
-    ],
-    "no-useless-concat": [
-      "error"
-    ],
-    "no-lone-blocks": [
-      "error"
-    ],
-    "no-extra-bind": [
-      "error"
-    ],
-    "no-unneeded-ternary": [
-      "error"
-    ],
-    "no-proto": [
-      "error"
-    ],
-    "no-void": [
-      "error"
-    ],
-    "no-invalid-this": [
-      "error"
-    ],
-    "no-alert": [
-      "off"
-    ],
-    "complexity": [
-      "error",
-      20
-    ],
-    "consistent-this": [
-      "off"
-    ],
-    "new-cap": [
-      "error"
-    ],
-    "new-parens": [
-      "error"
-    ],
-    "wrap-iife": [
-      "error"
-    ],
-    "require-jsdoc": [
-      "error"
-    ],
-    "radix": [
-      "off"
-    ],
-    "wrap-regex": [
-      "off"
-    ],
-    "vars-on-top": [
-      "error"
-    ],
-    "eol-last": [
-      "error",
-      "always"
-    ],
-    "arrow-parens": [
-      "off"
-    ],
-    "arrow-spacing": [
-      "error"
-    ],
-    "yoda": [
-      "error"
-    ],
-    "max-depth": [
-      "error",
-      4
-    ],
-    "sort-vars": [
-      "off"
-    ]
+    /* Possible Errors */
+    "for-direction": "error",
+    "getter-return": "error",
+    "no-compare-neg-zero": "error",
+    "no-cond-assign": "error",
+    "no-console": "error",
+    "no-constant-condition": "error",
+    "no-control-regex": "error",
+    "no-debugger": "error",
+    "no-dupe-args": "error",
+    "no-dupe-keys": "error",
+    "no-duplicate-case": "error",
+    "no-empty-character-class": "error",
+    "no-empty": "error",
+    "no-ex-assign": "error",
+    "no-extra-boolean-cast": "error",
+    "no-extra-parens": ["error", "all", {"nestedBinaryExpressions": false}],
+    "no-extra-semi": "error",
+    "no-func-assign": "error",
+    "no-inner-declarations": "error",
+    "no-invalid-regexp": "error",
+    "no-irregular-whitespace": "error",
+    "no-obj-calls": "error",
+    "no-regex-spaces": "error",
+    "no-sparse-arrays": "error",
+    "no-unexpected-multiline": "error",
+    "no-unreachable": "error",
+    "no-unsafe-finally": "error",
+    "no-unsafe-negation": "error",
+    "use-isnan": "error",
+    "valid-typeof": "error",
+  
+    /* Best Practices */
+    "complexity": ["warn", 20],
+    "curly": ["warn", "all"],
+    "default-case": "warn",
+    "dot-location": ["warn", "property"],
+    "dot-notation": "warn",
+    "no-caller": "warn",
+    "no-case-declarations": "warn",
+    "no-div-regex": "warn",
+    "no-else-return": "warn",
+    "no-empty-function": "warn",
+    "no-empty-pattern": "warn",
+    "no-eq-null": "warn",
+    "no-eval": "warn",
+    "no-extend-native": "warn",
+    "no-extra-bind": "warn",
+    "no-extra-label": "warn",
+    "no-fallthrough": "warn",
+    "no-floating-decimal": "warn",
+    "no-global-assign": "warn",
+    "no-implicit-globals": "warn",
+    "no-implied-eval": "warn",
+    "no-invalid-this": "warn",
+    "no-iterator": "warn",
+    "no-lone-blocks": "warn",
+    "no-loop-func": "warn",
+    "no-multi-spaces": "warn",
+    "no-multi-str": "warn",
+    "no-new-func": "warn",
+    "no-new-wrappers": "warn",
+    "no-new": "warn",    
+    "no-octal-escape": "warn",
+    "no-octal": "warn",
+    "no-param-reassign": "warn",
+    "no-proto": "warn",
+    "no-redeclare": "warn",
+    "no-return-assign": ["warn", "always"],
+    "no-script-url": "warn",
+    "no-self-assign": "warn",
+    "no-self-compare": "warn",
+    "no-sequences": "warn",
+    "no-unmodified-loop-condition": "warn",
+    "no-unused-expressions": "warn",
+    "no-unused-labels": "warn",
+    "no-useless-call": "warn",
+    "no-useless-concat": "warn",
+    "no-useless-escape": "warn",
+    "no-void": "warn",
+    "no-warning-comments": "warn",
+    "no-with": "warn",
+    "vars-on-top": "warn",
+    "wrap-iife": "warn",
+    "yoda": "warn",
+
+    /* Variables */
+    "no-delete-var": "error",
+    "no-label-var": "error",
+    "no-shadow-restricted-names": "error",
+    "no-shadow": "error",
+    "no-undef-init": "error",
+    "no-undef": "error",
+    "no-unused-vars": ["error", {"argsIgnorePattern": "^_"}],
+    "no-use-before-define": "error",
+
+    /* Stylistic Issues */
+    "array-bracket-spacing": "warn",
+    "brace-style": ["warn", "1tbs", {"allowSingleLine": true}],
+    "camelcase": "warn",
+    "comma-dangle": "warn",
+    "comma-spacing": "warn",
+    "comma-style": "warn",
+    "computed-property-spacing": "warn",
+    "eol-last": "warn",
+    "func-call-spacing": "warn",
+    "id-length": ["warn", {"min": 1, "max": 25}],
+    "indent": ["warn", 2],
+    "keyword-spacing": "warn",
+    "linebreak-style": ["warn", "unix"],
+    "max-depth": ["warn", 4],
+    "multiline-ternary": ["warn", "never"],
+    "new-cap": "warn",
+    "new-parens": "warn",
+    "no-array-constructor": "warn",
+    "no-continue": "warn",
+    "no-lonely-if": "warn",
+    "no-mixed-operators": "warn",
+    "no-mixed-spaces-and-tabs": "warn",
+    "no-multiple-empty-lines": ["warn", {"max": 1, "maxEOF": 1, "maxBOF": 0}],
+    "no-negated-condition": "warn",
+    "no-nested-ternary": "warn",
+    "no-new-object": "warn",
+    "no-tabs": "warn",
+    "no-trailing-spaces": "warn",
+    "no-unneeded-ternary": "warn",
+    "no-whitespace-before-property": "warn",
+    "object-curly-newline": "warn",
+    "object-curly-spacing": "warn",
+    "object-property-newline": "warn",
+    "one-var-declaration-per-line": "warn",
+    "operator-assignment": "warn",
+    "operator-linebreak": ["warn", "after"],
+    "padded-blocks": ["warn", "never"],
+    "quote-props": ["warn", "as-needed"],
+    "require-jsdoc": "warn",
+    "semi-spacing": "warn",
+    "semi": "warn",
+    "space-before-function-paren": ["warn", "never"],
+    "space-unary-ops": ["warn", {"words": true, "nonwords": false}],
+    "spaced-comment": "warn",
+
+    /* ECMAScript 6 */
+    "arrow-spacing": "error",
+    "constructor-super": "error",
+    "no-class-assign": "error",
+    "no-confusing-arrow": ["error", {"allowParens": false}],
+    "no-const-assign": "error",
+    "no-dupe-class-members": "error",
+    "no-duplicate-imports": "error",
+    "no-new-symbol": "error",
+    "no-this-before-super": "error",
+    "no-useless-computed-key": "error",
+    "no-useless-constructor": "error",
+    "no-useless-rename": "error",
+    "require-yield": "error",
+
+    /* Node.js and CommonJS */
+    "callback-return": "error",
+    "handle-callback-err": "error",
+    "no-mixed-requires": "error",
+    "no-new-require": "error",
+    "no-path-concat": "error",
+    "no-process-env": "error",
+    "no-process-exit": "error",
+    "no-sync": "error"
   }
 }


### PR DESCRIPTION
- Change the formatting of .eslintrc.json to use single line rules like the docs show, I think it looks nicer that way
- Sort rules by the categories in the docs: https://eslint.org/docs/rules/
- Make rules in the "Best Practices" and "Stylistic Issues" categories warnings instead of errors
- Instead of inheriting from `eslint:recommended`, I just copied all of those rules directly into this file (minus the ones that we are overriding) so we don't have to worry about that changing
- Updated a few deprecated rules

I updated CND with the new config and it looks like everything is still the same in Codacy.