### PR TITLE
Disable broken rule

### DIFF
--- a/configs/.stylelintrc.json
+++ b/configs/.stylelintrc.json
@@ -79,7 +79,8 @@
     "media-query-list-comma-newline-before": "never-multi-line",
     "media-query-list-comma-space-after": "always",
     "media-query-list-comma-space-before": "never",
-    "no-descending-specificity": true,
+    /* This rule is broken: https://github.com/stylelint/stylelint/issues/2489 */
+    // "no-descending-specificity": true,
     "no-duplicate-selectors": true,
     "no-empty-source": true,
     "no-eol-whitespace": true,


### PR DESCRIPTION
`no-descending-specificity` isn't compatible with sass, see here: https://github.com/stylelint/stylelint/issues/2489